### PR TITLE
Implement ConverHandler and write unit tests

### DIFF
--- a/controllers/convertHandler.js
+++ b/controllers/convertHandler.js
@@ -8,26 +8,51 @@
 
 function ConvertHandler() {
   this.getNum = function (input) {
-    var result;
-
+    var factor = input.split(/[A-Za-z]+/)[0].split("/");
+    var numerator = factor[0] === "" ? 1 : parseFloat(factor[0]);
+    var denominator = factor.length === 1 ? 1 : parseFloat(factor[1]);
+    var result = numerator / denominator;
+    if (Number.isNaN(result) || factor.length > 2) {
+      return "invalid number";
+    }
     return result;
   };
 
   this.getUnit = function (input) {
-    var result;
-
-    return result;
+    var unit = input.split(/^[^A-Za-z]+/)[0];
+    var result = unit.toLowerCase().match(/^(gal|l|mi|km|lbs|kg)$/);
+    if (result === null) {
+      return "invalid unit";
+    }
+    return unit;
   };
 
   this.getReturnUnit = function (initUnit) {
-    var result;
-
+    const imperialToMetric = {
+      gal: "l",
+      mi: "km",
+      lbs: "kg",
+    };
+    const metricToImperial = {
+      l: "gal",
+      km: "mi",
+      kg: "lbs",
+    };
+    var unit = initUnit.toLowerCase();
+    var result = imperialToMetric[unit] || metricToImperial[unit];
     return result;
   };
 
   this.spellOutUnit = function (unit) {
-    var result;
-
+    const fullForm = {
+      gal: "gallons",
+      l: "litres",
+      mi: "miles",
+      km: "kilometers",
+      lbs: "pounds",
+      kg: "kilograms",
+    };
+    var result = fullForm[unit.toLowerCase()];
     return result;
   };
 
@@ -35,14 +60,21 @@ function ConvertHandler() {
     const galToL = 3.78541;
     const lbsToKg = 0.453592;
     const miToKm = 1.60934;
-    var result;
+    const conversions = {
+      gal: galToL,
+      l: 1 / galToL,
+      lbs: lbsToKg,
+      kg: 1 / lbsToKg,
+      mi: miToKm,
+      km: 1 / miToKm,
+    };
+    var result = initNum * conversions[initUnit];
 
     return result;
   };
 
   this.getString = function (initNum, initUnit, returnNum, returnUnit) {
-    var result;
-
+    var result = `${initNum} ${initUnit} converts to ${returnNum} ${returnUnit}`;
     return result;
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "my-hyperdev-app",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,14 +3,15 @@
   "//2": "https://docs.npmjs.com/files/package.json",
   "//3": "updating this file will download and update your packages",
   "name": "my-hyperdev-app",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "What am I about?",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
     "lint-dockerfile": "dockerfilelint Dockerfile",
     "lint-yaml": "eslint . --ext .yml",
-    "prettier": "prettier --write ."
+    "prettier": "prettier --write .",
+    "test": "NODE_ENV=test node server.js"
   },
   "dependencies": {
     "body-parser": "^1.15.2",

--- a/tests/1_unit-tests.js
+++ b/tests/1_unit-tests.js
@@ -11,6 +11,8 @@ var assert = chai.assert;
 var ConvertHandler = require("../controllers/convertHandler.js");
 
 var convertHandler = new ConvertHandler();
+const INVALID_NUMBER = "invalid number";
+const INVALID_UNIT = "invalid unit";
 
 suite("Unit Tests", function () {
   suite("Function convertHandler.getNum(input)", function () {
@@ -21,29 +23,39 @@ suite("Unit Tests", function () {
     });
 
     test("Decimal Input", function (done) {
-      //done();
+      var input = "0.5kg";
+      assert.equal(convertHandler.getNum(input), 0.5);
+      done();
     });
 
     test("Fractional Input", function (done) {
-      //done();
+      var input = "2/8mi";
+      assert.equal(convertHandler.getNum(input), 0.25);
+      done();
     });
 
     test("Fractional Input w/ Decimal", function (done) {
-      //done();
+      var input = "7.5/2.5";
+      assert.equal(convertHandler.getNum(input), 3);
+      done();
     });
 
     test("Invalid Input (double fraction)", function (done) {
-      //done();
+      var input = "10//10kg";
+      assert.equal(convertHandler.getNum(input), INVALID_NUMBER);
+      done();
     });
 
     test("No Numerical Input", function (done) {
-      //done();
+      var input = "lbs";
+      assert.equal(convertHandler.getNum(input), 1);
+      done();
     });
   });
 
   suite("Function convertHandler.getUnit(input)", function () {
     test("For Each Valid Unit Inputs", function (done) {
-      var input = [
+      var inputs = [
         "gal",
         "l",
         "mi",
@@ -57,23 +69,25 @@ suite("Unit Tests", function () {
         "LBS",
         "KG",
       ];
-      input.forEach(function (ele) {
-        //assert
+      inputs.forEach(function (input) {
+        assert.equal(convertHandler.getUnit(input), input);
       });
       done();
     });
 
     test("Unknown Unit Input", function (done) {
-      //done();
+      var input = "10yards";
+      assert.equal(convertHandler.getUnit(input), INVALID_UNIT);
+      done();
     });
   });
 
   suite("Function convertHandler.getReturnUnit(initUnit)", function () {
     test("For Each Valid Unit Inputs", function (done) {
-      var input = ["gal", "l", "mi", "km", "lbs", "kg"];
+      var inputs = ["gal", "l", "mi", "km", "lbs", "kg"];
       var expect = ["l", "gal", "km", "mi", "kg", "lbs"];
-      input.forEach(function (ele, i) {
-        assert.equal(convertHandler.getReturnUnit(ele), expect[i]);
+      inputs.forEach(function (input, i) {
+        assert.equal(convertHandler.getReturnUnit(input), expect[i]);
       });
       done();
     });
@@ -81,7 +95,18 @@ suite("Unit Tests", function () {
 
   suite("Function convertHandler.spellOutUnit(unit)", function () {
     test("For Each Valid Unit Inputs", function (done) {
-      //see above example for hint
+      var inputs = ["gal", "l", "mi", "km", "lbs", "kg"];
+      var expect = [
+        "gallons",
+        "litres",
+        "miles",
+        "kilometers",
+        "pounds",
+        "kilograms",
+      ];
+      inputs.forEach(function (input, i) {
+        assert.equal(convertHandler.spellOutUnit(input), expect[i]);
+      });
       done();
     });
   });
@@ -99,23 +124,73 @@ suite("Unit Tests", function () {
     });
 
     test("L to Gal", function (done) {
-      //done();
+      var input = [2.2, "l"];
+      var expected = 0.58117;
+      assert.approximately(
+        convertHandler.convert(input[0], input[1]),
+        expected,
+        0.1
+      ); //0.1 tolerance
+      done();
     });
 
     test("Mi to Km", function (done) {
-      //done();
+      var input = [100, "mi"];
+      var expected = 160.934;
+      assert.approximately(
+        convertHandler.convert(input[0], input[1]),
+        expected,
+        0.1
+      ); //0.1 tolerance
+      done();
     });
 
     test("Km to Mi", function (done) {
-      //done();
+      var input = [16.00001, "km"];
+      var expected = 9.94197;
+      assert.approximately(
+        convertHandler.convert(input[0], input[1]),
+        expected,
+        0.1
+      ); //0.1 tolerance
+      done();
     });
 
     test("Lbs to Kg", function (done) {
-      //done();
+      var input = [25, "lbs"];
+      var expected = 11.3398;
+      assert.approximately(
+        convertHandler.convert(input[0], input[1]),
+        expected,
+        0.1
+      ); //0.1 tolerance
+      done();
     });
 
     test("Kg to Lbs", function (done) {
-      //done();
+      var input = [0.02, "kg"];
+      var expected = 0.00907;
+      assert.approximately(
+        convertHandler.convert(input[0], input[1]),
+        expected,
+        0.1
+      ); //0.1 tolerance
+      done();
+    });
+  });
+
+  suite("Function convertHandler.getString(unit)", function () {
+    test("With valid initial input and conversions", function (done) {
+      var initNum = 10,
+        initUnit = "gallons",
+        returnNum = 37.8541,
+        returnUnit = "liters";
+      var expect = "10 gallons converts to 37.8541 liters";
+      assert.equal(
+        convertHandler.getString(initNum, initUnit, returnNum, returnUnit),
+        expect
+      );
+      done();
     });
   });
 });


### PR DESCRIPTION
To run the tests locally, use `npm run test`. `ConvertHandler` stub is filled out.