### PR TITLE
Turn the error message from JSON to text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "my-hyperdev-app",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "//2": "https://docs.npmjs.com/files/package.json",
   "//3": "updating this file will download and update your packages",
   "name": "my-hyperdev-app",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "What am I about?",
   "main": "server.js",
   "scripts": {

--- a/routes/api.js
+++ b/routes/api.js
@@ -22,13 +22,13 @@ module.exports = function (app) {
     var initNum = convertHandler.getNum(input);
     var initUnit = convertHandler.getUnit(input);
     if (initNum === INVALID_NUMBER && initUnit === INVALID_UNIT) {
-      res.json({ error: "invalid number and unit" });
+      res.send("invalid number and unit");
       return;
     } else if (initNum === INVALID_NUMBER) {
-      res.json({ error: "invalid number" });
+      res.send("invalid number");
       return;
     } else if (initUnit === INVALID_UNIT) {
-      res.json({ error: "invalid unit" });
+      res.send("invalid unit");
       return;
     }
     var returnNum = convertHandler.convert(initNum, initUnit);

--- a/tests/2_functional-tests.js
+++ b/tests/2_functional-tests.js
@@ -38,7 +38,7 @@ suite("Functional Tests", function () {
           .query({ input: "32g" })
           .end(function (err, res) {
             assert.equal(res.status, 200);
-            assert.equal(res.body.error, "invalid unit");
+            assert.equal(res.text, "invalid unit");
             done();
           });
       });
@@ -50,7 +50,7 @@ suite("Functional Tests", function () {
           .query({ input: "3/7.2/4kg" })
           .end(function (err, res) {
             assert.equal(res.status, 200);
-            assert.equal(res.body.error, "invalid number");
+            assert.equal(res.text, "invalid number");
             done();
           });
       });
@@ -62,7 +62,7 @@ suite("Functional Tests", function () {
           .query({ input: "3/7.2/4kilomegagram" })
           .end(function (err, res) {
             assert.equal(res.status, 200);
-            assert.equal(res.body.error, "invalid number and unit");
+            assert.equal(res.text, "invalid number and unit");
             done();
           });
       });


### PR DESCRIPTION
The changes in the freeCodeCamp [requirements ](https://forum.freecodecamp.org/t/metric-imperial-converter-7th-test/420169) ask for a string to be returned.